### PR TITLE
[DOC] Typo in node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For publishing on opam see [opam_of_packagejson](https://github.com/bsansouci/op
 ## Build bytecode
 `npm run build`
 
-To build other targets (like native or js) you can call bsb directly (or add a script) with the `-backend` flag, like `./node_nodules/.bin/bsb -backend native` or `./node_nodules/.bin/bsb -backend js`.
+To build other targets (like native or js) you can call bsb directly (or add a script) with the `-backend` flag, like `./node_modules/.bin/bsb -backend native` or `./node_modules/.bin/bsb -backend js`.
 
 ## Run
 `./lib/bs/bytecode/index.byte`


### PR DESCRIPTION
Hi there,
It seems there was a typo in README.md for commands using `node_modules`